### PR TITLE
Add beforeStart($automatic,$force) callin:

### DIFF
--- a/src/spads.pl
+++ b/src/spads.pl
@@ -49,7 +49,7 @@ sub notall (&@) { my $c = shift; return defined first {! &$c} @_; }
 sub int32 { return unpack('l',pack('l',shift)) }
 sub uint32 { return unpack('L',pack('L',shift)) }
 
-our $spadsVer='0.11.37';
+our $spadsVer='0.11.38';
 
 my $win=$^O eq 'MSWin32' ? 1 : 0;
 
@@ -4105,7 +4105,17 @@ sub launchGame {
     answer("Unable to start game, $p_battleState->{warning} - use !forceStart to bypass") unless($automatic);
     return 0;
   }
-
+	
+  my $commandAllowed=1;
+  if(! $checkOnly) {
+	foreach my $pluginName (@pluginsOrder) {
+		$commandAllowed=$plugins{$pluginName}->beforeStart($automatic,$force) if($plugins{$pluginName}->can('beforeStart'));
+		last unless($commandAllowed);
+	}
+  }
+  
+  return 0 unless $commandAllowed;
+  
   my %additionalData=('game/AutohostPort' => $conf{autoHostPort},
                       'playerData' => {});
   $additionalData{'game/HostIP'}=$conf{forceHostIp};


### PR DESCRIPTION
beforeStart($automatic,$force)

This callback is called each time a before the SPADS launchgame command is going to be executed.

It must return 0 to prevent the command from being treated by other plugins and executed by SPADS core, or 1 to allow it.

Tested with this countdown  http://pastebin.com/PMsMDzGP spads plugin or elderberry autohost,  which adds a 5 second countdown before allowing the game to launch. Tested with returning both 0 and 1. The only issue is line 42 with :

$automatic = 0 if (!$automatic);

, which is a bit hacky, but without it the $automatic variable will not be initialised and there will be a warning in slog.