### PR TITLE
Remove the letters i, l, o and 0 from possible automatically generate…

### DIFF
--- a/src/spads.pl
+++ b/src/spads.pl
@@ -915,7 +915,7 @@ sub compareVersions {
 
 sub generatePassword {
   my $length=shift;
-  my @passwdChars=split("","abcdefghijklmnopqrstuvwxyz1234567890");
+  my @passwdChars=split("","abcdefghjkmnpqrstuvwxyz123456789");
   my $passwd="";
   for my $i (0..($length-1)) {
     $passwd.=$passwdChars[int(rand($#passwdChars+1))];


### PR DESCRIPTION
…d room passwords, as they have lead to multiple counts of confusion

Even though they can only be lowercase, but users dont know/expect that :D