### PR TITLE
Override LC_ALL instead of LANG

### DIFF
--- a/src/SpadsUpdater.pm
+++ b/src/SpadsUpdater.pm
@@ -601,14 +601,14 @@ sub uncompress7zipFile {
   my $sl=$self->{sLog};
   my $sevenZipBin=catfile($self->{localDir},$win?'7za.exe':'7za');
   $sl->log("Extracting sevenzip file \"$archiveFile\" into \"$destDir\"...",5);
-  my $previousEnvLangValue=$ENV{LANG};
-  $ENV{LANG}='C' unless($win);
+  my $previousEnvLangValue=$ENV{LC_ALL};
+  $ENV{LC_ALL}='C' unless($win);
   my ($exitCode,$errorMsg)=_systemNoOutput($sevenZipBin,'x','-y',"-o$destDir",$archiveFile,@filesToExtract);
   if(! $win) {
     if(defined $previousEnvLangValue) {
-      $ENV{LANG}=$previousEnvLangValue;
+      $ENV{LC_ALL}=$previousEnvLangValue;
     }else{
-      delete $ENV{LANG};
+      delete $ENV{LC_ALL};
     }
   }
   my $failReason;


### PR DESCRIPTION
This fixes the 7za binary crashing on Gentoo (sys-libs/glibc-2.36-r5, not sure if relevant):

```
$ LANG=C ./7za-16.2
7za-16.2: loadlocale.c:129: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed.
fish: Job 1, 'LANG=C ./7za-16.2' terminated by signal SIGABRT (Abort)
$ LC_ALL=C ./7za-16.2
7-Zip (a) [32] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,32 bits,16 CPUs x86)
[...]
```
Workaround options:
1. Run SPADS with `LC_ALL=C` or another non-UTF-8 locale.
3. Point the symlink for `7za` to the system binary. SPADS should revert this when its `7za` binary is updated: `ln -sf -t src/ /usr/bin/7za`.

The correct fix would be to update the distributed binary with one that can handle an UTF-8 locale.