### PR TITLE
Fix: URI-escape GitHub tags when downloading engines.

### DIFF
--- a/src/SpadsUpdater.pm
+++ b/src/SpadsUpdater.pm
@@ -952,7 +952,7 @@ sub _getEngineGithubDownloadUrl {
       }
     }
   }
-  my $httpRes=HTTP::Tiny->new(timeout => 10)->request('GET','https://github.com/'.$ghRepo.'/releases/expanded_assets/'.$ghTag);
+  my $httpRes=HTTP::Tiny->new(timeout => 10)->request('GET','https://github.com/'.$ghRepo.'/releases/expanded_assets/'.HTTP::Tiny->_uri_escape($ghTag));
   if($httpRes->{success}) {
     if($httpRes->{content} =~ /href="([^"]+\/$r_githubInfo->{asset})"/) {
       my $assetUrl=$1;


### PR DESCRIPTION
Consider the following repository and GitHub tag:
- Repo: `beyond-all-reason/spring`
- Tag: `spring_bar_{BAR105}105.1.1-2590-gb9462a0`

Currently, SpadsUpdater.pm constructs the following URL to look for a release to download:
- `https://github.com/beyond-all-reason/spring/releases/expanded_assets/spring_bar_{BAR105}105.1.1-2590-gb9462a0`

However, when HTTP:Tiny attempts a download using that URL, GitHub.com currently responds with an HTTP 404 error. This happens because the `{}` characters are not URI-safe, as is required per the HTTP::Tiny documentation:
- https://perldoc.perl.org/HTTP::Tiny#request
> The URL must have unsafe characters escaped and international domain names encoded.

This patch makes use of `HTTP::Tiny->_uri_escape` when constructing the URL, which ensures that the updater can find release files regardless of whether they are tagged with special characters.