### PR TITLE
Disallow endvote for unboss votes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1486,6 +1486,7 @@ SpadsPluginApi.pm:
 0.42: new plugin API customization callback "commandRightsOverride" (allows overriding access level requirements for calling SPADS commands)
 0.43: new plugin API function: "isSettingValueAllowed" (checks that a given value is allowed for a specific setting)
       fix links to tutorials in documentation
+0.44: disallow endvote for unboss votes
 
 SpadsUpdater.pm:
 ===============

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -8692,6 +8692,11 @@ sub hEndVote {
   }
 
   if(%currentVote && exists $currentVote{command}) {
+    my $command=lc(#currentVote{command}[0]);
+    if($command eq "unboss") {
+      answer("Unable to cancel vote (unboss cannot be canceled)");
+      return 0;
+    }
     return 1 if($checkOnly);
     sayBattleAndGame("Vote cancelled by $user");
     foreach my $pluginName (@pluginsOrder) {


### PR DESCRIPTION
Disclaimer: I have not tested these changes, as I am not familiar enough with the repo to do that. I'm creating this PR mostly to gauge your opinion on my suggestion.

With this PR, the "endvote" command will no longer work if the current vote is an "unboss" vote. This prevents preservation of autocracy by the current boss. I think the boss' ability to call "endvote" on "unboss" votes defeats the purpose of the "unboss" vote, and I frequently see this exploited in Beyond All Reason.

PS: This PR is basically the opposite of what https://github.com/beyond-all-reason/teiserver/issues/1065 suggests. As I prefer democracy, I'm against strengthening the boss mode.