### PR TITLE
Durable mod metadata cache + ghost mods (allowGhostMods)

### DIFF
--- a/etc/spads.conf
+++ b/etc/spads.conf
@@ -136,6 +136,7 @@ map:
 autoLoadMapPreset:0|1
 hideMapPresets:0|1
 allowGhostMaps:0|1
+allowGhostMods:0|1
 
 # Automatic features
 autoCallvote:1

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -392,6 +392,7 @@ my @levelsFields=(['level'],['description']);
 my @commandsFields=(['source','status','gameState'],['directLevel','voteLevel']);
 my @mapBoxesFields=(['mapName','nbTeams'],['boxes']);
 my @mapHashesFields=(['springMajorVersion','mapName'],['mapHash']);
+my @modHashesFields=(['springMajorVersion','modName'],['modHash']);
 my @userDataFieldsOld=(['accountId'],['country','cpu','lobbyClient','rank','timestamp','ips','names']);
 my @userDataFields=(['accountId'],['country','lobbyClient','rank','timestamp','ips','names']);
 my @springLobbyCertificatesFields=(['lobbyHost'],['certHashes']);
@@ -545,6 +546,13 @@ sub new {
     return 0;
   }
 
+  touch($p_conf->{''}{instanceDir}.'/modHashes.dat') unless(-f $p_conf->{''}{instanceDir}.'/modHashes.dat');
+  my $p_modHashes=loadFastTableFile($sLog,$p_conf->{''}{instanceDir}.'/modHashes.dat',\@modHashesFields,{});
+  if(! %{$p_modHashes}) {
+    $sLog->log('Unable to load mod hashes',1);
+    return 0;
+  }
+
   my $p_springLobbyCertificates={''=>{}};
   if(-f "$spadsDir/springLobbyCertificates.dat") {
     $p_springLobbyCertificates=loadFastTableFile($sLog,"$spadsDir/springLobbyCertificates.dat",\@springLobbyCertificatesFields,{});
@@ -586,6 +594,16 @@ sub new {
     return 0;
   }
 
+  my $p_modInfoCache={};
+  my $modInfoCacheFile=$p_conf->{''}{instanceDir}.'/modInfoCache.dat';
+  if(-f $modInfoCacheFile) {
+    $p_modInfoCache=retrieve($modInfoCacheFile);
+  }
+  if(! defined $p_modInfoCache) {
+    $sLog->log('Unable to load mod info cache',1);
+    return 0;
+  }
+
   my $p_trustedLobbyCertificates={};
   if($sharedDataTs{trustedLobbyCertificates}) {
     $p_trustedLobbyCertificates=initSharedData($sLog,$p_conf,\%sharedDataTs,'trustedLobbyCertificates',$sharedDataFiles{trustedLobbyCertificates});
@@ -615,6 +633,7 @@ sub new {
     mapBoxes => $p_mapBoxes->{''},
     savedBoxes => $p_savedBoxes->{''},
     mapHashes => $p_mapHashes->{''},
+    modHashes => $p_modHashes->{''},
     users => $p_users->{''},
     help => $p_help,
     helpSettings => $p_helpSettings,
@@ -631,6 +650,7 @@ sub new {
     ipIds => $p_ipIds,
     nameIds => $p_nameIds,
     mapInfoCache => $p_mapInfoCache,
+    modInfoCache => $p_modInfoCache,
     maps => {},
     orderedMaps => [],
     ghostMaps => {},
@@ -2815,6 +2835,7 @@ sub dumpDynamicData {
     $self->dumpFastTable($p_prunedPrefs,$self->{conf}{instanceDir}.'/preferences.dat',\@preferencesListsFields);
   }
   $self->dumpFastTable($self->{mapHashes},$self->{conf}{instanceDir}.'/mapHashes.dat',\@mapHashesFields);
+  $self->dumpFastTable($self->{modHashes},$self->{conf}{instanceDir}.'/modHashes.dat',\@modHashesFields);
   my $p_userData=flushUserDataCache($self);
   $self->dumpFastTable($p_userData,$self->{conf}{instanceDir}.'/userData.dat',\@userDataFields);
   my $dumpDuration=time-$startDumpTs;
@@ -2903,6 +2924,22 @@ sub cacheMapsInfo {
   $self->{log}->log('Unable to store map info cache',1) unless($res);
 }
 
+# Business functions - Dynamic data - Mod info cache ##########################
+
+sub getCachedModInfo {
+  my ($self,$mod)=@_;
+  return $self->{modInfoCache}{$mod} if(exists $self->{modInfoCache}{$mod});
+  return undef;
+}
+
+sub cacheModInfo {
+  my ($self,$mod,$p_modInfo)=@_;
+  $self->{modInfoCache}{$mod}=$p_modInfo;
+  my $res=nstore($self->{modInfoCache},$self->{conf}{instanceDir}.'/modInfoCache.dat');
+  $self->{log}->log('Unable to store mod info cache',1) unless($res);
+  return $res;
+}
+
 # Business functions - Dynamic data - Map boxes ###############################
 
 sub existSavedMapBoxes {
@@ -2981,6 +3018,23 @@ sub saveMapHash {
   $self->{mapHashes}{$springMajorVersion}{$map}={} unless(exists $self->{mapHashes}{$springMajorVersion}{$map});
   $self->{mapHashes}{$springMajorVersion}{$map}{mapHash}=$hash;
   $self->{log}->log("Hash saved for map \"$map\" (springMajorVersion=$springMajorVersion)",5);
+  return 1;
+}
+
+sub getModHash {
+  my ($self,$mod,$springMajorVersion)=@_;
+  if(exists $self->{modHashes}{$springMajorVersion} && exists $self->{modHashes}{$springMajorVersion}{$mod}) {
+    return $self->{modHashes}{$springMajorVersion}{$mod}{modHash};
+  }
+  return 0;
+}
+
+sub saveModHash {
+  my ($self,$mod,$springMajorVersion,$hash)=@_;
+  $self->{modHashes}{$springMajorVersion}={} unless(exists $self->{modHashes}{$springMajorVersion});
+  $self->{modHashes}{$springMajorVersion}{$mod}={} unless(exists $self->{modHashes}{$springMajorVersion}{$mod});
+  $self->{modHashes}{$springMajorVersion}{$mod}{modHash}=$hash;
+  $self->{log}->log("Hash saved for mod \"$mod\" (springMajorVersion=$springMajorVersion)",5);
   return 1;
 }
 

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -212,7 +212,8 @@ my %spadsSectionParameters = (description => ['notNull'],
                               freeSettings => ['settingList'],
                               allowModOptionsValues => ['bool'],
                               allowMapOptionsValues => ['bool'],
-                              allowGhostMaps =>['bool']);
+                              allowGhostMaps =>['bool'],
+                              allowGhostMods =>['bool']);
 
 my %hostingParameters = (description => ['notNull'],
                          battleName => ['notNull'],

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -1514,11 +1514,19 @@ sub updateTargetMod {
             unless($loadArchivesInProgress);
         return 2;
       }
+      if(! defined $modRegexp && canUseGhostMod($configuredModName)) {
+        $targetMod=$configuredModName;
+        return 1;
+      }
       slog('Unable to find mod '.(defined $modRegexp ? "matching regular expression \"$modRegexp\"" : "\"$configuredModName\""),1);
       $targetMod='';
       return 0;
     }
     if(! defined $modRegexp && defined $cachedMods{$configuredModName}) {
+      $targetMod=$configuredModName;
+      return 1;
+    }
+    if(! defined $modRegexp && canUseGhostMod($configuredModName)) {
       $targetMod=$configuredModName;
       return 1;
     }
@@ -1957,6 +1965,8 @@ sub loadArchivesPostActions {
             if($printModUpdateMsg && $lobbyState >= LOBBY_STATE_BATTLE_OPENED && $lobby->{battles}{$lobby->{battle}{battleId}}{mod} ne $newTargetMod);
         $targetMod=$newTargetMod;
       }
+    }elsif(canUseGhostMod($configuredModNameDuringReload)) {
+      $targetMod=$configuredModNameDuringReload;
     }else{
       $targetMod='';
     }
@@ -2032,6 +2042,17 @@ sub getModSides {
   return $cachedMods{$modName}{sides} if(exists $cachedMods{$modName});
   my $p_modInfo=$spads->getCachedModInfo($modName);
   return defined $p_modInfo ? $p_modInfo->{sides} : [];
+}
+
+# A configured mod whose archive is absent can still be hosted by a dedicated
+# server if its hash and full info (options+sides) were previously cached. Both
+# are required, so we never open a battle with incomplete mod metadata.
+sub canUseGhostMod {
+  my $modName=shift;
+  return 0 unless($conf{allowGhostMods} && $springServerType eq 'dedicated');
+  return 0 if($modName eq '');
+  return 0 unless($spads->getModHash($modName,$syncedSpringVersion));
+  return defined $spads->getCachedModInfo($modName) ? 1 : 0;
 }
 
 sub getMapOptions {

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -2013,17 +2013,25 @@ sub getMapHashAndArchive {
 
 sub getModHash {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{hash} : 0;
+  return 0 if($modName eq '');
+  return $cachedMods{$modName}{hash} if(exists $cachedMods{$modName});
+  return $spads->getModHash($modName,$syncedSpringVersion);
 }
 
 sub getModOptions {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{options} : {};
+  return {} if($modName eq '');
+  return $cachedMods{$modName}{options} if(exists $cachedMods{$modName});
+  my $p_modInfo=$spads->getCachedModInfo($modName);
+  return defined $p_modInfo ? $p_modInfo->{options} : {};
 }
 
 sub getModSides {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{sides} : [];
+  return [] if($modName eq '');
+  return $cachedMods{$modName}{sides} if(exists $cachedMods{$modName});
+  my $p_modInfo=$spads->getCachedModInfo($modName);
+  return defined $p_modInfo ? $p_modInfo->{sides} : [];
 }
 
 sub getMapOptions {

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -1938,7 +1938,13 @@ sub loadArchivesPostActions {
     %rapidModResolutionCache=(substr($configuredModNameDuringReload,8) => $newTargetMod)
         if(substr($configuredModNameDuringReload,0,8) eq 'rapid://');
     my $r_modData=$r_loadArchivesResult->{modData};
-    $cachedMods{$newTargetMod}=$r_modData if(defined $r_modData); # modData is only defined when a new uncached mod is selected
+    if(defined $r_modData) { # modData is only defined when a new uncached mod is selected
+      $cachedMods{$newTargetMod}=$r_modData;
+      if($r_modData->{hash}) {
+        $spads->saveModHash($newTargetMod,$syncedSpringVersion,$r_modData->{hash});
+        $spads->cacheModInfo($newTargetMod,{options => $r_modData->{options}, sides => $r_modData->{sides}});
+      }
+    }
     $nbArchivesLoaded = $nbMapsLoaded + (scalar(%availableModsNameToNb) || 1);
   }else{
     $nbArchivesLoaded = ($nbMapsLoaded + %availableModsNameToNb) || 1;

--- a/var/helpSettings.dat
+++ b/var/helpSettings.dat
@@ -1123,6 +1123,16 @@ A map preset is a global preset defined in spads.conf which has the same name as
 -
 0
 
+[set:allowGhostMods]
+Allow ghost mods
+-
+If enabled and if a dedicated Spring server is used (see [global:springServerType]), the configured game (mod) can be hosted even when its archive isn't available locally, as long as its hash and full metadata (options and sides) have already been cached from a previous load. This mirrors [set:allowGhostMaps] for games.
+-
+0: disabled
+1: enabled
+-
+0
+
 [set:allowGhostMaps]
 Allow ghost maps
 -


### PR DESCRIPTION
## Summary

SPADS persists full **map** metadata durably (`mapInfoCache.dat` for start
positions/dimensions/options, `mapHashes.dat` for version-keyed hashes), but
**mod** metadata (hash, options, sides) only ever lived in the in-memory
`%cachedMods` and was lost on restart. As a result there was no "ghost mod"
equivalent to ghost maps: a dedicated relay host always required the game
archive locally, even though it never simulates.

This PR mirrors the existing map machinery for mods and adds a `allowGhostMods`
setting so a dedicated host can host a configured game whose archive is absent,
using previously-cached metadata.

## Changes

- **Durable mod cache** (`SpadsConf.pm`): `modHashes.dat` (version-keyed
  checksums, dumped in `dumpDynamicData` alongside `mapHashes.dat`) and
  `modInfoCache.dat` (Storable: options + sides). New accessors
  `getCachedModInfo` / `cacheModInfo` / `getModHash` / `saveModHash`.
- **Persist on load** (`loadArchivesPostActions`): a mod's hash and info are
  written to the durable cache the first time its archive is loaded.
- **Cache-aware accessors**: `getModHash` / `getModOptions` / `getModSides`
  now fall back to the durable cache, mirroring `getMapHash` / `getMapOptions`.
- **`allowGhostMods` setting** (preset setting, mirrors `allowGhostMaps`) plus
  `canUseGhostMod()` and ghost-mod resolution in `updateTargetMod()` and on
  initial load.

## Design notes

The data splits cleanly by version-sensitivity: the checksum is
engine-version-sensitive (kept keyed by `springMajorVersion`, like map hashes),
while options and sides are intrinsic to the archive (version-independent).

`canUseGhostMod()` requires **both** a version-matching cached hash **and**
cached info (options + sides) before a ghost mod is used, so a battle is never
opened with incomplete mod metadata.

Existing configs need `allowGhostMods` added to `spads.conf` (handled by the
normal config update flow, as with any new setting). Generated setting docs
(`doc/*.html`) are not updated in this PR.

## Testing status (please read)

This is **compile-checked only, not runtime-tested.** The repo has no automated
tests, and I was not able to run SPADS in my environment (no Spring/unitsync
install), so I verified each change with `perl -c` only. The open-battle path in
particular should be exercised on a real dedicated host before this is relied
on. Feedback on correctness and on anything I've missed is very welcome.

Scope is the "complete the cache" half of the work; an optional external
metadata import/export/fetch layer is intentionally left out of this PR.