### PR TITLE
External ghost metadata provider (import/export + periodic refresh)

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -132,6 +132,9 @@ battle,pv:player,spec:stopped|10:10
 :player,spec:|100:
 ::|100:
 
+[exportMetadata]
+::|120:
+
 [fixColors]
 battle,pv:player:stopped|10:10
 ::|100:

--- a/etc/spads.conf
+++ b/etc/spads.conf
@@ -43,6 +43,8 @@ springDataDir:%springDataDir%
 autoReloadArchivesMinDelay:30
 sequentialUnitsync:0
 autoLearnMaps:0
+ghostMetadataSources:
+ghostMetadataRefreshDelay:0
 springConfig:
 
 # Output flood protections

--- a/etc/spads.conf
+++ b/etc/spads.conf
@@ -136,6 +136,7 @@ map:
 autoLoadMapPreset:0|1
 hideMapPresets:0|1
 allowGhostMaps:0|1
+allowGhostMods:0|1
 
 # Automatic features
 autoCallvote:1

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -3018,13 +3018,44 @@ sub getMetadataForExport {
   };
 }
 
+# Defensive validation for externally-imported metadata. Rejects control
+# characters (which could otherwise inject lines into the generated Spring start
+# script via option keys/values), unexpected reference types (e.g. code refs),
+# and pathologically deep nesting. decode_json only produces hashes, arrays,
+# scalars and JSON::PP::Boolean, so anything else is treated as hostile.
+sub _importedValueIsSafe {
+  my ($value,$depth)=@_;
+  return 0 if($depth > 8);
+  my $ref=ref $value;
+  if($ref eq '') {
+    return 1 if(! defined $value);
+    return $value =~ /[\x00-\x08\x0a-\x1f\x7f]/ ? 0 : 1;
+  }
+  return 1 if($ref eq 'JSON::PP::Boolean');
+  if($ref eq 'HASH') {
+    foreach my $key (keys %{$value}) {
+      return 0 if($key =~ /[\x00-\x08\x0a-\x1f\x7f]/);
+      return 0 unless(_importedValueIsSafe($value->{$key},$depth+1));
+    }
+    return 1;
+  }
+  if($ref eq 'ARRAY') {
+    foreach my $element (@{$value}) {
+      return 0 unless(_importedValueIsSafe($element,$depth+1));
+    }
+    return 1;
+  }
+  return 0;
+}
+
 # Merge an exported metadata structure into the local stores. Local (archive-
 # derived) entries are never overwritten; previously imported entries are
 # refreshed. Only hashes for the host's spring major version are imported (map
-# and mod info are version-independent). Returns counts {added,updated,skipped}.
+# and mod info are version-independent). Entries failing validation are counted
+# as rejected. Returns counts {added,updated,skipped,rejected}.
 sub importMetadataStructure {
   my ($self,$r_dump,$springMajorVersion)=@_;
-  my %stats=(added => 0, updated => 0, skipped => 0);
+  my %stats=(added => 0, updated => 0, skipped => 0, rejected => 0);
   return \%stats unless(ref $r_dump eq 'HASH');
 
   my %hashStores=(mapHashes => ['mapHash','mapHash'], modHashes => ['modHash','modHash']);
@@ -3035,6 +3066,10 @@ sub importMetadataStructure {
     next unless(ref $r_versionDump eq 'HASH' && ref $r_versionDump->{$springMajorVersion} eq 'HASH');
     my $r_entries=$r_versionDump->{$springMajorVersion};
     foreach my $name (keys %{$r_entries}) {
+      if($name =~ /[\x00-\x08\x0a-\x1f\x7f]/ || ref $r_entries->{$name} || $r_entries->{$name} !~ /^-?\d+$/) {
+        $stats{rejected}++;
+        next;
+      }
       my $exists=(ref $self->{$selfKey}{$springMajorVersion} eq 'HASH' && exists $self->{$selfKey}{$springMajorVersion}{$name});
       if($exists && ! $self->_isImportedMetadata($provType,$springMajorVersion,$name)) {
         $stats{skipped}++;
@@ -3057,6 +3092,10 @@ sub importMetadataStructure {
     my $r_entries=$r_dump->{$dumpKey};
     next unless(ref $r_entries eq 'HASH');
     foreach my $name (keys %{$r_entries}) {
+      if($name =~ /[\x00-\x08\x0a-\x1f\x7f]/ || ref $r_entries->{$name} ne 'HASH' || ! _importedValueIsSafe($r_entries->{$name},0)) {
+        $stats{rejected}++;
+        next;
+      }
       my $exists=exists $self->{$selfKey}{$name};
       if($exists && ! $self->_isImportedMetadata($provType,$name)) {
         $stats{skipped}++;
@@ -3075,6 +3114,9 @@ sub importMetadataStructure {
     nstore($self->{modInfoCache},$self->{conf}{instanceDir}.'/modInfoCache.dat');
     $self->_storeImportedMetadata();
   }
+
+  $self->{log}->log("Rejected $stats{rejected} unsafe or malformed imported metadata entrie(s)",2)
+      if($stats{rejected});
 
   return \%stats;
 }

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -605,6 +605,16 @@ sub new {
     return 0;
   }
 
+  my $p_importedMetadata={};
+  my $importedMetadataFile=$p_conf->{''}{instanceDir}.'/importedMetadata.dat';
+  if(-f $importedMetadataFile) {
+    $p_importedMetadata=retrieve($importedMetadataFile);
+  }
+  if(! defined $p_importedMetadata) {
+    $sLog->log('Unable to load imported metadata registry',1);
+    return 0;
+  }
+
   my $p_trustedLobbyCertificates={};
   if($sharedDataTs{trustedLobbyCertificates}) {
     $p_trustedLobbyCertificates=initSharedData($sLog,$p_conf,\%sharedDataTs,'trustedLobbyCertificates',$sharedDataFiles{trustedLobbyCertificates});
@@ -652,6 +662,7 @@ sub new {
     nameIds => $p_nameIds,
     mapInfoCache => $p_mapInfoCache,
     modInfoCache => $p_modInfoCache,
+    importedMetadata => $p_importedMetadata,
     maps => {},
     orderedMaps => [],
     ghostMaps => {},
@@ -2914,6 +2925,7 @@ sub cacheMapsInfo {
   }
   foreach my $map (keys %{$p_mapsInfo}) {
     $self->{mapInfoCache}{$map}=$p_mapsInfo->{$map};
+    $self->_clearImported('mapInfo',$map);
   }
   my $res;
   if($self->{sharedDataTs}{mapInfoCache}) {
@@ -2936,9 +2948,133 @@ sub getCachedModInfo {
 sub cacheModInfo {
   my ($self,$mod,$p_modInfo)=@_;
   $self->{modInfoCache}{$mod}=$p_modInfo;
+  $self->_clearImported('modInfo',$mod);
   my $res=nstore($self->{modInfoCache},$self->{conf}{instanceDir}.'/modInfoCache.dat');
   $self->{log}->log('Unable to store mod info cache',1) unless($res);
   return $res;
+}
+
+# Business functions - Dynamic data - Metadata import/export ##################
+
+# Provenance registry ($self->{importedMetadata}): records which cached entries
+# came from an external import. Absence means the entry is local (archive-
+# derived) and authoritative. Types: 'mapHash'/'modHash' (keys: version,name),
+# 'mapInfo'/'modInfo' (key: name).
+
+sub _storeImportedMetadata {
+  my $self=shift;
+  my $res=nstore($self->{importedMetadata},$self->{conf}{instanceDir}.'/importedMetadata.dat');
+  $self->{log}->log('Unable to store imported metadata registry',1) unless($res);
+  return $res;
+}
+
+sub _isImportedMetadata {
+  my ($self,$type,@keys)=@_;
+  my $node=$self->{importedMetadata}{$type};
+  foreach my $key (@keys) {
+    return 0 unless(ref $node eq 'HASH' && exists $node->{$key});
+    $node=$node->{$key};
+  }
+  return 1;
+}
+
+sub _markImportedMetadata {
+  my ($self,$type,@keys)=@_;
+  my $leaf=pop(@keys);
+  my $node=($self->{importedMetadata}{$type}//={});
+  $node=($node->{$_}//={}) foreach(@keys);
+  $node->{$leaf}=1;
+}
+
+sub _clearImported {
+  my ($self,$type,@keys)=@_;
+  my $leaf=pop(@keys);
+  my $node=$self->{importedMetadata}{$type};
+  foreach my $key (@keys) {
+    return unless(ref $node eq 'HASH' && exists $node->{$key});
+    $node=$node->{$key};
+  }
+  delete $node->{$leaf} if(ref $node eq 'HASH');
+}
+
+sub getMetadataForExport {
+  my $self=shift;
+  my %mapHashes;
+  foreach my $ver (keys %{$self->{mapHashes}}) {
+    $mapHashes{$ver}{$_}=$self->{mapHashes}{$ver}{$_}{mapHash} foreach(keys %{$self->{mapHashes}{$ver}});
+  }
+  my %modHashes;
+  foreach my $ver (keys %{$self->{modHashes}}) {
+    $modHashes{$ver}{$_}=$self->{modHashes}{$ver}{$_}{modHash} foreach(keys %{$self->{modHashes}{$ver}});
+  }
+  return {
+    spadsMetadataVersion => 1,
+    mapHashes => \%mapHashes,
+    modHashes => \%modHashes,
+    mapInfo => $self->{mapInfoCache},
+    modInfo => $self->{modInfoCache},
+  };
+}
+
+# Merge an exported metadata structure into the local stores. Local (archive-
+# derived) entries are never overwritten; previously imported entries are
+# refreshed. Only hashes for the host's spring major version are imported (map
+# and mod info are version-independent). Returns counts {added,updated,skipped}.
+sub importMetadataStructure {
+  my ($self,$r_dump,$springMajorVersion)=@_;
+  my %stats=(added => 0, updated => 0, skipped => 0);
+  return \%stats unless(ref $r_dump eq 'HASH');
+
+  my %hashStores=(mapHashes => ['mapHash','mapHash'], modHashes => ['modHash','modHash']);
+  foreach my $dumpKey (qw'mapHashes modHashes') {
+    my ($selfKey,$hashField,$provType)=($dumpKey,@{$hashStores{$dumpKey}});
+    next unless(defined $springMajorVersion);
+    my $r_versionDump=$r_dump->{$dumpKey};
+    next unless(ref $r_versionDump eq 'HASH' && ref $r_versionDump->{$springMajorVersion} eq 'HASH');
+    my $r_entries=$r_versionDump->{$springMajorVersion};
+    foreach my $name (keys %{$r_entries}) {
+      my $exists=(ref $self->{$selfKey}{$springMajorVersion} eq 'HASH' && exists $self->{$selfKey}{$springMajorVersion}{$name});
+      if($exists && ! $self->_isImportedMetadata($provType,$springMajorVersion,$name)) {
+        $stats{skipped}++;
+        next;
+      }
+      $self->{$selfKey}{$springMajorVersion}//={};
+      $self->{$selfKey}{$springMajorVersion}{$name}={$hashField => $r_entries->{$name}};
+      $self->_markImportedMetadata($provType,$springMajorVersion,$name);
+      $exists ? $stats{updated}++ : $stats{added}++;
+    }
+  }
+
+  my $skipMapInfo=$self->{sharedDataTs}{mapInfoCache} ? 1 : 0;
+  $self->{log}->log('Map info import skipped (mapInfoCache is shared across instances)',2)
+      if($skipMapInfo && ref $r_dump->{mapInfo} eq 'HASH' && %{$r_dump->{mapInfo}});
+  my %infoStores=(mapInfo => ['mapInfoCache','mapInfo'], modInfo => ['modInfoCache','modInfo']);
+  foreach my $dumpKey (qw'mapInfo modInfo') {
+    next if($dumpKey eq 'mapInfo' && $skipMapInfo);
+    my ($selfKey,$provType)=@{$infoStores{$dumpKey}};
+    my $r_entries=$r_dump->{$dumpKey};
+    next unless(ref $r_entries eq 'HASH');
+    foreach my $name (keys %{$r_entries}) {
+      my $exists=exists $self->{$selfKey}{$name};
+      if($exists && ! $self->_isImportedMetadata($provType,$name)) {
+        $stats{skipped}++;
+        next;
+      }
+      $self->{$selfKey}{$name}=$r_entries->{$name};
+      $self->_markImportedMetadata($provType,$name);
+      $exists ? $stats{updated}++ : $stats{added}++;
+    }
+  }
+
+  if($stats{added} + $stats{updated} > 0) {
+    $self->dumpFastTable($self->{mapHashes},$self->{conf}{instanceDir}.'/mapHashes.dat',\@mapHashesFields);
+    $self->dumpFastTable($self->{modHashes},$self->{conf}{instanceDir}.'/modHashes.dat',\@modHashesFields);
+    nstore($self->{mapInfoCache},$self->{conf}{instanceDir}.'/mapInfoCache.dat') unless($skipMapInfo);
+    nstore($self->{modInfoCache},$self->{conf}{instanceDir}.'/modInfoCache.dat');
+    $self->_storeImportedMetadata();
+  }
+
+  return \%stats;
 }
 
 # Business functions - Dynamic data - Map boxes ###############################
@@ -3018,6 +3154,7 @@ sub saveMapHash {
   $self->{mapHashes}{$springMajorVersion}={} unless(exists $self->{mapHashes}{$springMajorVersion});
   $self->{mapHashes}{$springMajorVersion}{$map}={} unless(exists $self->{mapHashes}{$springMajorVersion}{$map});
   $self->{mapHashes}{$springMajorVersion}{$map}{mapHash}=$hash;
+  $self->_clearImported('mapHash',$springMajorVersion,$map);
   $self->{log}->log("Hash saved for map \"$map\" (springMajorVersion=$springMajorVersion)",5);
   return 1;
 }
@@ -3035,6 +3172,7 @@ sub saveModHash {
   $self->{modHashes}{$springMajorVersion}={} unless(exists $self->{modHashes}{$springMajorVersion});
   $self->{modHashes}{$springMajorVersion}{$mod}={} unless(exists $self->{modHashes}{$springMajorVersion}{$mod});
   $self->{modHashes}{$springMajorVersion}{$mod}{modHash}=$hash;
+  $self->_clearImported('modHash',$springMajorVersion,$mod);
   $self->{log}->log("Hash saved for mod \"$mod\" (springMajorVersion=$springMajorVersion)",5);
   return 1;
 }

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -392,6 +392,7 @@ my @levelsFields=(['level'],['description']);
 my @commandsFields=(['source','status','gameState'],['directLevel','voteLevel']);
 my @mapBoxesFields=(['mapName','nbTeams'],['boxes']);
 my @mapHashesFields=(['springMajorVersion','mapName'],['mapHash']);
+my @modHashesFields=(['springMajorVersion','modName'],['modHash']);
 my @userDataFieldsOld=(['accountId'],['country','cpu','lobbyClient','rank','timestamp','ips','names']);
 my @userDataFields=(['accountId'],['country','lobbyClient','rank','timestamp','ips','names']);
 my @springLobbyCertificatesFields=(['lobbyHost'],['certHashes']);
@@ -545,6 +546,13 @@ sub new {
     return 0;
   }
 
+  touch($p_conf->{''}{instanceDir}.'/modHashes.dat') unless(-f $p_conf->{''}{instanceDir}.'/modHashes.dat');
+  my $p_modHashes=loadFastTableFile($sLog,$p_conf->{''}{instanceDir}.'/modHashes.dat',\@modHashesFields,{});
+  if(! %{$p_modHashes}) {
+    $sLog->log('Unable to load mod hashes',1);
+    return 0;
+  }
+
   my $p_springLobbyCertificates={''=>{}};
   if(-f "$spadsDir/springLobbyCertificates.dat") {
     $p_springLobbyCertificates=loadFastTableFile($sLog,"$spadsDir/springLobbyCertificates.dat",\@springLobbyCertificatesFields,{});
@@ -586,6 +594,16 @@ sub new {
     return 0;
   }
 
+  my $p_modInfoCache={};
+  my $modInfoCacheFile=$p_conf->{''}{instanceDir}.'/modInfoCache.dat';
+  if(-f $modInfoCacheFile) {
+    $p_modInfoCache=retrieve($modInfoCacheFile);
+  }
+  if(! defined $p_modInfoCache) {
+    $sLog->log('Unable to load mod info cache',1);
+    return 0;
+  }
+
   my $p_trustedLobbyCertificates={};
   if($sharedDataTs{trustedLobbyCertificates}) {
     $p_trustedLobbyCertificates=initSharedData($sLog,$p_conf,\%sharedDataTs,'trustedLobbyCertificates',$sharedDataFiles{trustedLobbyCertificates});
@@ -615,6 +633,7 @@ sub new {
     mapBoxes => $p_mapBoxes->{''},
     savedBoxes => $p_savedBoxes->{''},
     mapHashes => $p_mapHashes->{''},
+    modHashes => $p_modHashes->{''},
     users => $p_users->{''},
     help => $p_help,
     helpSettings => $p_helpSettings,
@@ -631,6 +650,7 @@ sub new {
     ipIds => $p_ipIds,
     nameIds => $p_nameIds,
     mapInfoCache => $p_mapInfoCache,
+    modInfoCache => $p_modInfoCache,
     maps => {},
     orderedMaps => [],
     ghostMaps => {},
@@ -2815,6 +2835,7 @@ sub dumpDynamicData {
     $self->dumpFastTable($p_prunedPrefs,$self->{conf}{instanceDir}.'/preferences.dat',\@preferencesListsFields);
   }
   $self->dumpFastTable($self->{mapHashes},$self->{conf}{instanceDir}.'/mapHashes.dat',\@mapHashesFields);
+  $self->dumpFastTable($self->{modHashes},$self->{conf}{instanceDir}.'/modHashes.dat',\@modHashesFields);
   my $p_userData=flushUserDataCache($self);
   $self->dumpFastTable($p_userData,$self->{conf}{instanceDir}.'/userData.dat',\@userDataFields);
   my $dumpDuration=time-$startDumpTs;
@@ -2903,6 +2924,22 @@ sub cacheMapsInfo {
   $self->{log}->log('Unable to store map info cache',1) unless($res);
 }
 
+# Business functions - Dynamic data - Mod info cache ##########################
+
+sub getCachedModInfo {
+  my ($self,$mod)=@_;
+  return $self->{modInfoCache}{$mod} if(exists $self->{modInfoCache}{$mod});
+  return undef;
+}
+
+sub cacheModInfo {
+  my ($self,$mod,$p_modInfo)=@_;
+  $self->{modInfoCache}{$mod}=$p_modInfo;
+  my $res=nstore($self->{modInfoCache},$self->{conf}{instanceDir}.'/modInfoCache.dat');
+  $self->{log}->log('Unable to store mod info cache',1) unless($res);
+  return $res;
+}
+
 # Business functions - Dynamic data - Map boxes ###############################
 
 sub existSavedMapBoxes {
@@ -2981,6 +3018,23 @@ sub saveMapHash {
   $self->{mapHashes}{$springMajorVersion}{$map}={} unless(exists $self->{mapHashes}{$springMajorVersion}{$map});
   $self->{mapHashes}{$springMajorVersion}{$map}{mapHash}=$hash;
   $self->{log}->log("Hash saved for map \"$map\" (springMajorVersion=$springMajorVersion)",5);
+  return 1;
+}
+
+sub getModHash {
+  my ($self,$mod,$springMajorVersion)=@_;
+  if(exists $self->{modHashes}{$springMajorVersion} && exists $self->{modHashes}{$springMajorVersion}{$mod}) {
+    return $self->{modHashes}{$springMajorVersion}{$mod}{modHash};
+  }
+  return 0;
+}
+
+sub saveModHash {
+  my ($self,$mod,$springMajorVersion,$hash)=@_;
+  $self->{modHashes}{$springMajorVersion}={} unless(exists $self->{modHashes}{$springMajorVersion});
+  $self->{modHashes}{$springMajorVersion}{$mod}={} unless(exists $self->{modHashes}{$springMajorVersion}{$mod});
+  $self->{modHashes}{$springMajorVersion}{$mod}{modHash}=$hash;
+  $self->{log}->log("Hash saved for mod \"$mod\" (springMajorVersion=$springMajorVersion)",5);
   return 1;
 }
 

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -212,7 +212,8 @@ my %spadsSectionParameters = (description => ['notNull'],
                               freeSettings => ['settingList'],
                               allowModOptionsValues => ['bool'],
                               allowMapOptionsValues => ['bool'],
-                              allowGhostMaps =>['bool']);
+                              allowGhostMaps =>['bool'],
+                              allowGhostMods =>['bool']);
 
 my %hostingParameters = (description => ['notNull'],
                          battleName => ['notNull'],

--- a/src/SpadsConf.pm
+++ b/src/SpadsConf.pm
@@ -138,7 +138,9 @@ my %globalParameters = (lobbyLogin => ['login'],
                         useWin32Process => ['useWin32ProcessType'],
                         autoLoadPlugins => ['pluginList','null'],
                         eventModel => ['eventModelType'],
-                        maxChildProcesses => ['integer']);
+                        maxChildProcesses => ['integer'],
+                        ghostMetadataSources => [],
+                        ghostMetadataRefreshDelay => ['integer']);
 
 my %spadsSectionParameters = (description => ['notNull'],
                               commandsFile => ['notNull'],

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -201,6 +201,7 @@ my %SPADS_CORE_CMD_HANDLERS = (
   clearbox => \&hClearBox,
   closebattle => \&hCloseBattle,
   endvote => \&hEndVote,
+  exportmetadata => \&hExportMetadata,
   fixcolors => \&hFixColors,
   force => \&hForce,
   forcepreset => \&hForcePreset,
@@ -11587,6 +11588,40 @@ sub hSaveBoxes {
   $smfMapName.='.smf' unless($smfMapName =~ /\.smf$/);
   $spads->saveMapBoxes($smfMapName,$p_startRects,$conf{extraBox});
   answer("Start boxes saved for map $conf{map}");
+  return 1;
+}
+
+sub hExportMetadata {
+  my ($source,$user,$p_params,$checkOnly)=@_;
+
+  if($#{$p_params} > 0) {
+    invalidSyntax($user,"exportmetadata");
+    return 0;
+  }
+
+  return 1 if($checkOnly);
+
+  my $fileName=$p_params->[0] // 'metadataExport.json';
+  $fileName =~ s/.*[\/\\]//;
+  $fileName.='.json' unless($fileName =~ /\.json$/i);
+  my $filePath=catfile($conf{instanceDir},$fileName);
+
+  my $r_metadata=$spads->getMetadataForExport();
+  my $jsonString=eval { JSON::PP->new->canonical->pretty->encode($r_metadata) };
+  if(! defined $jsonString) {
+    answer("Unable to encode metadata for export");
+    return 0;
+  }
+  my $fh;
+  if(! open($fh,'>',$filePath)) {
+    answer("Unable to write metadata export file \"$filePath\" ($!)");
+    return 0;
+  }
+  print {$fh} $jsonString;
+  close($fh);
+  my $nbMaps=keys %{$r_metadata->{mapInfo}};
+  my $nbMods=keys %{$r_metadata->{modInfo}};
+  answer("Metadata exported to \"$fileName\" ($nbMaps maps, $nbMods mods)");
   return 1;
 }
 

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -1514,11 +1514,19 @@ sub updateTargetMod {
             unless($loadArchivesInProgress);
         return 2;
       }
+      if(! defined $modRegexp && canUseGhostMod($configuredModName)) {
+        $targetMod=$configuredModName;
+        return 1;
+      }
       slog('Unable to find mod '.(defined $modRegexp ? "matching regular expression \"$modRegexp\"" : "\"$configuredModName\""),1);
       $targetMod='';
       return 0;
     }
     if(! defined $modRegexp && defined $cachedMods{$configuredModName}) {
+      $targetMod=$configuredModName;
+      return 1;
+    }
+    if(! defined $modRegexp && canUseGhostMod($configuredModName)) {
       $targetMod=$configuredModName;
       return 1;
     }
@@ -1957,6 +1965,8 @@ sub loadArchivesPostActions {
             if($printModUpdateMsg && $lobbyState >= LOBBY_STATE_BATTLE_OPENED && $lobby->{battles}{$lobby->{battle}{battleId}}{mod} ne $newTargetMod);
         $targetMod=$newTargetMod;
       }
+    }elsif(canUseGhostMod($configuredModNameDuringReload)) {
+      $targetMod=$configuredModNameDuringReload;
     }else{
       $targetMod='';
     }
@@ -2032,6 +2042,17 @@ sub getModSides {
   return $cachedMods{$modName}{sides} if(exists $cachedMods{$modName});
   my $p_modInfo=$spads->getCachedModInfo($modName);
   return defined $p_modInfo ? $p_modInfo->{sides} : [];
+}
+
+# A configured mod whose archive is absent can still be hosted by a dedicated
+# server if its hash and full info (options+sides) were previously cached. Both
+# are required, so we never open a battle with incomplete mod metadata.
+sub canUseGhostMod {
+  my $modName=shift;
+  return 0 unless($conf{allowGhostMods} && $springServerType eq 'dedicated');
+  return 0 if($modName eq '');
+  return 0 unless($spads->getModHash($modName,$syncedSpringVersion));
+  return defined $spads->getCachedModInfo($modName) ? 1 : 0;
 }
 
 sub getMapOptions {

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -2064,7 +2064,7 @@ sub fetchMetadataDump {
   my $source=shift;
   my $content;
   if($source =~ /^https?:\/\//i) {
-    my $httpRes=HTTP::Tiny->new(timeout => 30)->request('GET',$source);
+    my $httpRes=HTTP::Tiny->new(timeout => 30, verify_SSL => 1)->request('GET',$source);
     return (undef,"HTTP error ($httpRes->{status} $httpRes->{reason})") unless($httpRes->{success});
     $content=$httpRes->{content};
   }else{
@@ -2086,7 +2086,7 @@ sub fetchMetadataDump {
 sub importGhostMetadataFromSources {
   my @sources=grep {$_ ne ''} split(/;/,$conf{ghostMetadataSources});
   return unless(@sources);
-  my %total=(added => 0, updated => 0, skipped => 0);
+  my %total=(added => 0, updated => 0, skipped => 0, rejected => 0);
   foreach my $source (@sources) {
     my ($r_dump,$errMsg)=fetchMetadataDump($source);
     if(! defined $r_dump) {
@@ -2099,7 +2099,7 @@ sub importGhostMetadataFromSources {
   }
   if($total{added} + $total{updated} > 0) {
     $spads->applyMapList(\@availableMaps,$syncedSpringVersion);
-    slog("Ghost metadata import complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped})",3);
+    slog("Ghost metadata import complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped}, rejected=$total{rejected})",3);
   }
 }
 
@@ -2122,7 +2122,7 @@ sub refreshGhostMetadata {
         sub {
           my $r_results=shift;
           return unless(ref $r_results eq 'ARRAY');
-          my %total=(added => 0, updated => 0, skipped => 0);
+          my %total=(added => 0, updated => 0, skipped => 0, rejected => 0);
           foreach my $r_result (@{$r_results}) {
             if(! defined $r_result->{dump}) {
               slog("Unable to refresh ghost metadata from \"$r_result->{source}\": $r_result->{error}",2);
@@ -2133,7 +2133,7 @@ sub refreshGhostMetadata {
           }
           if($total{added} + $total{updated} > 0) {
             $spads->applyMapList(\@availableMaps,$syncedSpringVersion);
-            slog("Ghost metadata refresh complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped})",3);
+            slog("Ghost metadata refresh complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped}, rejected=$total{rejected})",3);
           }
         })) {
     slog('Unable to fork process for ghost metadata refresh',2);

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -2013,17 +2013,25 @@ sub getMapHashAndArchive {
 
 sub getModHash {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{hash} : 0;
+  return 0 if($modName eq '');
+  return $cachedMods{$modName}{hash} if(exists $cachedMods{$modName});
+  return $spads->getModHash($modName,$syncedSpringVersion);
 }
 
 sub getModOptions {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{options} : {};
+  return {} if($modName eq '');
+  return $cachedMods{$modName}{options} if(exists $cachedMods{$modName});
+  my $p_modInfo=$spads->getCachedModInfo($modName);
+  return defined $p_modInfo ? $p_modInfo->{options} : {};
 }
 
 sub getModSides {
   my $modName=shift;
-  return ($modName ne '' && exists $cachedMods{$modName}) ? $cachedMods{$modName}{sides} : [];
+  return [] if($modName eq '');
+  return $cachedMods{$modName}{sides} if(exists $cachedMods{$modName});
+  my $p_modInfo=$spads->getCachedModInfo($modName);
+  return defined $p_modInfo ? $p_modInfo->{sides} : [];
 }
 
 sub getMapOptions {

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -1938,7 +1938,13 @@ sub loadArchivesPostActions {
     %rapidModResolutionCache=(substr($configuredModNameDuringReload,8) => $newTargetMod)
         if(substr($configuredModNameDuringReload,0,8) eq 'rapid://');
     my $r_modData=$r_loadArchivesResult->{modData};
-    $cachedMods{$newTargetMod}=$r_modData if(defined $r_modData); # modData is only defined when a new uncached mod is selected
+    if(defined $r_modData) { # modData is only defined when a new uncached mod is selected
+      $cachedMods{$newTargetMod}=$r_modData;
+      if($r_modData->{hash}) {
+        $spads->saveModHash($newTargetMod,$syncedSpringVersion,$r_modData->{hash});
+        $spads->cacheModInfo($newTargetMod,{options => $r_modData->{options}, sides => $r_modData->{sides}});
+      }
+    }
     $nbArchivesLoaded = $nbMapsLoaded + (scalar(%availableModsNameToNb) || 1);
   }else{
     $nbArchivesLoaded = ($nbMapsLoaded + %availableModsNameToNb) || 1;

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -31,6 +31,7 @@ use FindBin;
 use IO::Uncompress::Gunzip '$GunzipError';
 use IPC::Cmd 'can_run';
 use JSON::PP;
+use HTTP::Tiny;
 use List::Util qw'first any all none notall shuffle reduce';
 use MIME::Base64;
 use POSIX qw'ceil uname';
@@ -2053,6 +2054,52 @@ sub canUseGhostMod {
   return 0 if($modName eq '');
   return 0 unless($spads->getModHash($modName,$syncedSpringVersion));
   return defined $spads->getCachedModInfo($modName) ? 1 : 0;
+}
+
+# Read a metadata dump from a local file or an http(s) URL, returning
+# ($r_decodedDump,$errMsg). No SPADS state is mutated, so this is safe to run in
+# a forked child for periodic refresh.
+sub fetchMetadataDump {
+  my $source=shift;
+  my $content;
+  if($source =~ /^https?:\/\//i) {
+    my $httpRes=HTTP::Tiny->new(timeout => 30)->request('GET',$source);
+    return (undef,"HTTP error ($httpRes->{status} $httpRes->{reason})") unless($httpRes->{success});
+    $content=$httpRes->{content};
+  }else{
+    if(! open(my $fh,'<',$source)) {
+      return (undef,"unable to open file ($!)");
+    }else{
+      local $/=undef;
+      $content=<$fh>;
+      close($fh);
+    }
+  }
+  my $r_dump=eval { decode_json($content) };
+  return (undef,'invalid JSON'.($@ ? " ($@)" : '')) unless(ref $r_dump eq 'HASH');
+  return ($r_dump,undef);
+}
+
+# Import ghost metadata from all configured sources into the local stores, then
+# rebuild the ghost map list so newly imported maps become selectable.
+sub importGhostMetadataFromSources {
+  my @sources=grep {$_ ne ''} split(/;/,$conf{ghostMetadataSources});
+  return unless(@sources);
+  my %total=(added => 0, updated => 0, skipped => 0);
+  foreach my $source (@sources) {
+    my ($r_dump,$errMsg)=fetchMetadataDump($source);
+    if(! defined $r_dump) {
+      slog("Unable to import ghost metadata from \"$source\": $errMsg",2);
+      next;
+    }
+    my $r_stats=$spads->importMetadataStructure($r_dump,$syncedSpringVersion);
+    $total{$_}+=$r_stats->{$_} foreach(keys %{$r_stats});
+    slog("Imported ghost metadata from \"$source\" (added=$r_stats->{added}, updated=$r_stats->{updated}, skipped=$r_stats->{skipped})",4);
+  }
+  if($total{added} + $total{updated} > 0) {
+    $spads->applyMapList(\@availableMaps,$syncedSpringVersion);
+    slog("Ghost metadata import complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped})",3);
+  }
 }
 
 sub getMapOptions {
@@ -15897,6 +15944,7 @@ if(! $abortSpadsStartForAutoUpdate) {
   }
   slog("Loading Spring archives using unitsync library version $syncedSpringVersion ...",3);
   fatalError('Unable to load Spring archives at startup') unless(loadArchives());
+  importGhostMetadataFromSources() if($conf{ghostMetadataSources} ne '');
   setDefaultMapOfMaplist() if($conf{map} eq '');
 
 # Init #################################

--- a/src/spads.pl
+++ b/src/spads.pl
@@ -2102,6 +2102,43 @@ sub importGhostMetadataFromSources {
   }
 }
 
+# Periodic refresh: fetch all sources in a forked child (network I/O must not
+# block the main loop), then apply the results in the parent process where the
+# SPADS state lives. Imported/previously-imported entries are refreshed; local
+# archive-derived entries are never touched.
+sub refreshGhostMetadata {
+  my @sources=grep {$_ ne ''} split(/;/,$conf{ghostMetadataSources});
+  return unless(@sources);
+  if(! SimpleEvent::forkCall(
+        sub {
+          my @results;
+          foreach my $source (@sources) {
+            my ($r_dump,$errMsg)=fetchMetadataDump($source);
+            push(@results,{source => $source, dump => $r_dump, error => $errMsg});
+          }
+          return \@results;
+        },
+        sub {
+          my $r_results=shift;
+          return unless(ref $r_results eq 'ARRAY');
+          my %total=(added => 0, updated => 0, skipped => 0);
+          foreach my $r_result (@{$r_results}) {
+            if(! defined $r_result->{dump}) {
+              slog("Unable to refresh ghost metadata from \"$r_result->{source}\": $r_result->{error}",2);
+              next;
+            }
+            my $r_stats=$spads->importMetadataStructure($r_result->{dump},$syncedSpringVersion);
+            $total{$_}+=$r_stats->{$_} foreach(keys %{$r_stats});
+          }
+          if($total{added} + $total{updated} > 0) {
+            $spads->applyMapList(\@availableMaps,$syncedSpringVersion);
+            slog("Ghost metadata refresh complete (added=$total{added}, updated=$total{updated}, skipped=$total{skipped})",3);
+          }
+        })) {
+    slog('Unable to fork process for ghost metadata refresh',2);
+  }
+}
+
 sub getMapOptions {
   my $mapName=shift;
   my $p_mapInfo=$spads->getCachedMapInfo($mapName);
@@ -16007,6 +16044,8 @@ if(! $abortSpadsStartForAutoUpdate) {
       if($autoManagedEngineData{mode} eq 'release' && $autoManagedEngineData{delay});
   SimpleEvent::addTimer('RefreshSharedData',$conf{sharedDataRefreshDelay},$conf{sharedDataRefreshDelay},sub {$spads->refreshSharedDataIfNeeded()})
       if($conf{sharedDataRefreshDelay});
+  SimpleEvent::addTimer('RefreshGhostMetadata',$conf{ghostMetadataRefreshDelay}*60,$conf{ghostMetadataRefreshDelay}*60,\&refreshGhostMetadata)
+      if($conf{ghostMetadataRefreshDelay} && $conf{ghostMetadataSources} ne '');
   SimpleEvent::startLoop(\&postMainLoop);
 }
 
@@ -16224,6 +16263,7 @@ sub postMainLoop {
   SimpleEvent::removeTimer('SpadsMainLoop');
   SimpleEvent::removeTimer('EngineVersionAutoManagement') if($autoManagedEngineData{mode} eq 'release' && $autoManagedEngineData{delay});
   SimpleEvent::removeTimer('RefreshSharedData') if($conf{sharedDataRefreshDelay});
+  SimpleEvent::removeTimer('RefreshGhostMetadata') if($conf{ghostMetadataRefreshDelay} && $conf{ghostMetadataSources} ne '');
   SimpleEvent::removeFileLockRequest('unitsyncLock') if($timestamps{usLockRequestForGameStart});
 }
 

--- a/var/help.dat
+++ b/var/help.dat
@@ -117,6 +117,9 @@
 [endVote]
 !endVote - cancels current vote
 
+[exportMetadata]
+!exportMetadata [<fileName>] - exports cached map and mod metadata (hashes, options, sides) as JSON to the instance directory for sharing with other hosts
+
 [fixColors]
 !fixColors - tries to fix colors automatically
 

--- a/var/helpSettings.dat
+++ b/var/helpSettings.dat
@@ -297,6 +297,25 @@ Any writable directory
 -
 spring
 
+[global:ghostMetadataSources]
+Ghost metadata sources
+-
+Semicolon-separated list of metadata sources (local file paths and/or http(s) URLs) from which map and game metadata (hashes, options, sides and start positions) is imported at startup. This populates the ghost map and ghost game caches, so that maps and games whose archives aren't available locally can still be hosted (refer to [set:allowGhostMaps] and [set:allowGhostMods]). Imported metadata never overrides metadata derived from locally available archives.
+-
+<null> (metadata import disabled)
+Semicolon-separated list of file paths and/or http(s) URLs
+-
+<null>
+
+[global:ghostMetadataRefreshDelay]
+Ghost metadata refresh delay
+-
+Delay in minutes between automatic refreshes of the metadata imported from the sources defined in [global:ghostMetadataSources]. On each refresh the sources are re-fetched and previously imported entries are updated, while metadata derived from local archives is left untouched. A value of 0 disables periodic refresh.
+-
+Integer
+-
+0
+
 [global:springConfig]
 Spring config file path
 -


### PR DESCRIPTION
## Summary

Builds on top of #87 (durable mod metadata cache + ghost mods). This branch is
stacked on that one, so it **includes the commits from #87** as well as the Part
C work below; if #87 is merged first, only the Part C commits remain.

Part C makes the metadata cache shareable between hosts, so a dedicated relay can
be seeded with map/mod metadata it never loaded locally, then kept current.

## Changes (Part C)

- **Export** (`!exportMetadata [<file>]`, admin level 120): writes the cached
  map/mod metadata (version-keyed hashes + options/sides/start positions) as
  pretty, canonical JSON to the instance directory.
- **Import**: new `ghostMetadataSources` setting (semicolon-separated list of
  local file paths and/or `http(s)://` URLs, fetched with `HTTP::Tiny`). Imported
  at startup.
- **Periodic refresh**: new `ghostMetadataRefreshDelay` setting (minutes). A
  SimpleEvent timer re-fetches the sources via `forkCall` (network I/O off the
  main loop) and applies the results in the parent process.
- **Provenance + merge rule**: a separate `importedMetadata.dat` registry records
  which cached entries came from import. Local (archive-derived) entries are never
  overwritten; previously-imported entries are refreshed. A real archive load
  reclaims authority (self-heal). Only hashes matching the host's spring major
  version are imported; map/mod info is version-independent.

All new settings default to disabled, so existing hosts are unaffected until an
operator opts in. JSON via core `JSON::PP`; no new dependencies. Map info import
is skipped when `mapInfoCache` is shared across instances (logged).

## Testing status (please read)

Like #87, this is **compile-checked only (`perl -c`), not runtime-tested** - the
repo has no automated tests and I could not run SPADS in my environment. Someone
has offered to test this on a real host; I wanted the branch available for that.
Review and correction very welcome, particularly on the import/refresh paths and
the start-up ordering relative to the ghost map list rebuild.