### PR TITLE
Add a compile-check test and CI workflow

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,15 @@
+name: compile-check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show Perl version
+        run: perl --version
+      - name: Compile-check all sources
+        run: prove -v t/

--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+#
+# Compile-check (perl -c) every Perl source under src/.
+#
+# SPADS depends on sibling modules (SimpleLog, SimpleEvent, SpringLobbyInterface,
+# SpringAutoHostInterface, SpringLobbyProtocol) which are fetched at install time
+# and are not vendored in this repository. To allow a syntax/compile check of the
+# SPADS sources without a full installation, we generate minimal stubs for them.
+#
+# This verifies that the sources PARSE and COMPILE; it does not verify runtime
+# behaviour. It is the cheapest possible regression net for a codebase that
+# currently has no other automated tests.
+
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw'tempdir';
+use File::Spec;
+use FindBin;
+
+my $srcDir = File::Spec->rel2abs(File::Spec->catdir($FindBin::Bin, File::Spec->updir, 'src'));
+my $repoDir = File::Spec->catdir($srcDir, File::Spec->updir);
+
+my @stubModules = qw'SimpleLog SimpleEvent SpringLobbyInterface SpringAutoHostInterface SpringLobbyProtocol';
+
+my $stubDir = tempdir(CLEANUP => 1);
+for my $mod (@stubModules) {
+  my $file = File::Spec->catfile($stubDir, "$mod.pm");
+  open(my $fh, '>', $file) or die "Unable to create stub \"$file\": $!";
+  print {$fh} "package $mod;\nsub new { bless {}, shift }\nsub AUTOLOAD { }\nsub DESTROY { }\n1;\n";
+  close($fh);
+}
+
+my @sources = sort (glob("$srcDir/*.pl"), glob("$srcDir/*.pm"));
+@sources or BAIL_OUT("No Perl sources found in \"$srcDir\"");
+
+for my $src (@sources) {
+  my $rel = File::Spec->abs2rel($src, $repoDir);
+  my $output = '';
+  my $pid = open(my $fh, '-|');
+  defined $pid or die "fork failed: $!";
+  if (! $pid) {
+    open(STDERR, '>&', \*STDOUT);
+    exec($^X, "-I$stubDir", "-I$srcDir", '-c', $src);
+    exit 127;
+  }
+  {
+    local $/;
+    $output = <$fh>;
+  }
+  close($fh);
+  ok($? == 0, "perl -c $rel") or diag($output);
+}
+
+done_testing();


### PR DESCRIPTION
## What

Adds the first automated check to the repository:

- `t/00-compile.t` runs `perl -c` on every source under `src/`. The sibling
  modules (`SimpleLog`, `SimpleEvent`, `SpringLobbyInterface`,
  `SpringAutoHostInterface`, `SpringLobbyProtocol`) are fetched at install time
  and not vendored here, so the test generates minimal stubs for them, just
  enough for a compile check.
- `.github/workflows/compile.yml` runs the test via `prove` on push and pull
  request, using only core Perl modules (no dependency installation needed).

## Why

There is currently no automated test of any kind. This is the cheapest possible
regression net: it catches parse/compile errors, lexical-scope mistakes, and
`strict` violations across the whole tree on every change. It deliberately does
NOT attempt to verify runtime behaviour (that needs a real Spring/unitsync
install), so it stays fast, hermetic, and dependency-free.

Verified locally: `prove -v t/` passes (9/9 sources compile).

## Note

This is a proposal and imposes a small amount of CI maintenance, so feel free to
treat it as a starting point or close it if the approach isn't wanted. It's the
foundation a few follow-ups (a `cpanfile`, a perlcritic step, and eventually unit
tests around the config/data layer) would build on, but each of those is kept as
its own separate PR.