### PR TITLE
Add cpanfile for non-core dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,32 @@
+# cpanfile - non-core Perl dependencies for SPADS.
+#
+# Core modules that ship with Perl (e.g. HTTP::Tiny, JSON::PP, Storable,
+# Time::HiRes, List::Util, File::Spec) are not listed here.
+#
+# INSTALL.md remains the authoritative reference, including the recommended
+# system-package names (e.g. libffi-platypus-perl, libio-socket-ssl-perl,
+# libdbd-sqlite3-perl) which are usually preferable to installing from CPAN.
+#
+# Install everything declared here with:  cpanm --installdeps .
+
+on 'runtime' => sub {
+  if ($^O eq 'MSWin32') {
+    # Windows: unitsync is accessed through Win32::API; these ship with
+    # Strawberry Perl.
+    requires 'Win32';
+    requires 'Win32::API';
+    requires 'Win32::TieRegistry';
+  }
+  else {
+    # Non-Windows: the unitsync library is loaded through FFI.
+    requires 'FFI::Platypus';
+  }
+
+  # Recommended: required by lobby servers using TLS (e.g. the official Spring
+  # lobby server), for automatic engine installation from GitHub, and for
+  # automatic download of some map sets.
+  recommends 'IO::Socket::SSL';
+
+  # Recommended for multi-instance mode (shared data stored in SQLite).
+  recommends 'DBD::SQLite';
+};


### PR DESCRIPTION
## What

Adds a `cpanfile` declaring the non-core Perl modules currently described only in
prose in `INSTALL.md`:

- `FFI::Platypus` (required, non-Windows) / `Win32`, `Win32::API`,
  `Win32::TieRegistry` (Windows), gated on `$^O`
- `IO::Socket::SSL` (recommended)
- `DBD::SQLite` (recommended, multi-instance mode)

## Why

Makes the dependencies machine-readable, enabling `cpanm --installdeps .` and use
by CI. Core modules are intentionally omitted, and `INSTALL.md` remains
authoritative for the preferred system-package install method (the cpanfile
comments point back to it).

Purely additive; no runtime code is touched. Validated that the file evaluates
cleanly and declares the expected modules.