### PR TITLE
Add advisory perlcritic config and CI

### DIFF
--- a/.github/workflows/perlcritic.yml
+++ b/.github/workflows/perlcritic.yml
@@ -1,0 +1,19 @@
+name: perlcritic
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  perlcritic:
+    runs-on: ubuntu-latest
+    # Advisory only: this codebase has not previously been linted, so a finding
+    # must not fail the build. Remove continue-on-error once the policy is
+    # tightened and outstanding findings are addressed.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Perl::Critic
+        run: sudo apt-get update && sudo apt-get install -y libperl-critic-perl
+      - name: Run perlcritic (advisory)
+        run: perlcritic --profile .perlcriticrc src/

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,10 @@
+# Perl::Critic configuration for SPADS.
+#
+# This codebase has not previously been linted, so the policy starts deliberately
+# lenient: only the most severe issues (severity 5) are reported. The threshold
+# can be lowered over time (toward severity 1) as findings are triaged.
+#
+# The accompanying CI job is advisory (non-blocking) for the same reason.
+
+severity = 5
+verbose  = 8


### PR DESCRIPTION
## What

- `.perlcriticrc`: a deliberately lenient starting policy (severity 5 only).
- `.github/workflows/perlcritic.yml`: a GitHub Actions job that runs `perlcritic`
  over `src/`, marked `continue-on-error` so it is **advisory and never fails the
  build**.

## Why

Adds a static-analysis signal without imposing a wall of findings on a codebase
that has not previously been linted. perlcritic uses PPI (static parsing) so it
needs none of the runtime/sibling dependencies. The intent is to start gentle and
tighten the severity threshold (and drop `continue-on-error`) over time as
findings are triaged.

## Honest caveat

`perlcritic` was not available in my environment, so I could not run it against
the tree locally — the config and workflow are standard but the actual findings
(and the exact severity that produces a useful, non-noisy result) should be
confirmed from the first CI run. Starting advisory means a surprising result
can't break anything.